### PR TITLE
Fix the Uguu uploader and SICP crash on no auth

### DIFF
--- a/app/src/main/kotlin/science/itaintrocket/pomfshare/HostListActivity.kt
+++ b/app/src/main/kotlin/science/itaintrocket/pomfshare/HostListActivity.kt
@@ -27,7 +27,7 @@ class HostListActivity() : FragmentActivity(), RequestAuthenticationDialog.Reque
         // This should probably be stored in a proper format at some point, but cba now
         hosts.add(Host("Pomf.cat", "https://pomf.cat/upload.php?output=gyazo", "75MiB", Host.Type.POMF))
         hosts.add(Host("SICP", "https://sicp.me/", "25MiB", Host.Type.UGUU, authRequired = true))
-        hosts.add(Host("Uguu", "https://uguu.se/api.php?d=upload-tool", "100MiB, 24 hours", Host.Type.UGUU))
+        hosts.add(Host("Uguu", "https://uguu.se/upload.php?output=gyazo", "128MiB, 48 hours", Host.Type.POMF))
 
         // If authentication data exists for a host, load it
         loadHostAuthentications()

--- a/app/src/main/kotlin/science/itaintrocket/pomfshare/Uploader.kt
+++ b/app/src/main/kotlin/science/itaintrocket/pomfshare/Uploader.kt
@@ -47,6 +47,9 @@ class Uploader(private val source: MainActivity, private val contentUri: Uri, pr
     // domain in the result, e.g. https://example.com/https://example.com/file.jpg
     // This method extracts the correct url from such a result
     private fun extractUrl(result: String): String {
+        if (!result.contains(':')) {
+            return result
+        }
         val protocol = result.substring(0, result.indexOf(':')) // http or https?
         val index = result.lastIndexOf("$protocol://")
         return if (index > 0) {


### PR DESCRIPTION
Note: I have no idea whether `Host.Type.POMF` and `Host.Type.UGUU` should really be called after pomf and uguu; I'm too late to the pomf.se party to know who was the first or what was the standard back then. However, pomf.cat and uguu.se seem to be based on a single codebase (and both use `files[]` not `file`), while sicp.me is different (uses `file`). So maybe the enum constants should be renamed.

Also, in uguu.se `gyazo` and `text` response types are synonyms, but I put `gyazo` in to be consistent with the pomf.cat definition.

Also, it seems like hostings supported don't exhibit the weird behavior described in the `extractUrl` function, so maybe it should be ditched altogether.